### PR TITLE
Make command options better

### DIFF
--- a/src/edusat.cpp
+++ b/src/edusat.cpp
@@ -623,17 +623,16 @@ int main(int argc, char** argv){
 	cout << "======================================================" << endl;
 	cout << "This is hacked edusat by Basel and Thomas :)" << endl;
 	cout << "======================================================" << endl << endl;
-	bool with_proof;
-	parse_options(argc, argv, with_proof);
-	ifstream in (argv[argc - 1 - with_proof]);
+	parse_options(argc, argv);
+	ifstream in (argv[argc - 1]);
 	if (!in.good())
 		Abort("cannot read input file", 1);
-	if (with_proof) {
-		std::string out(argv[argc - with_proof]);
+	if (options["proof"]->val() != "") {
+		std::string out(options["proof"]->val());
 		S.set_proof_file(out);
-		cout << "Dumping proof to " << argv[argc - 1] << endl << endl;
+		cout << "Dumping proof to " << out << endl << endl;
 	}
-	cout << "Reading CNF from " << argv[argc - 1 - with_proof] << endl;
+	cout << "Reading CNF from " << argv[argc - 1] << endl;
 	S.read_cnf(in);
 	in.close();
 	

--- a/src/edusat.h
+++ b/src/edusat.h
@@ -36,6 +36,7 @@ typedef vector<Lit> trail_t;
 #define Assignment_file "assignment.txt"
 
 int verbose = 0;
+string proof_path = "";
 double begin_time;
 double timeout = 0.0;
 
@@ -62,7 +63,8 @@ VAL_DEC_HEURISTIC ValDecHeuristic = VAL_DEC_HEURISTIC::PHASESAVING;
 unordered_map<string, option*> options = {
 	{"v",           new intoption(&verbose, 0, 2, "Verbosity level")},
 	{"timeout",     new doubleoption(&timeout, 0.0, 36000.0, "Timeout in seconds")},
-	{"valdh",       new intoption((int*)&ValDecHeuristic, 0, 1, "{0: phase-saving, 1: literal-score}")}
+	{"valdh",       new intoption((int*)&ValDecHeuristic, 0, 1, "{0: phase-saving, 1: literal-score}")},
+	{"proof", 	 	new stringoption(&proof_path, "Path to proof file")}
 };
 
 

--- a/src/options.h
+++ b/src/options.h
@@ -2,12 +2,21 @@
 #include <string>
 using namespace std;
 
+enum OptionType {
+	BOOL_OPTION,
+	INT_OPTION,
+	DOUBLE_OPTION,
+	STRING_OPTION
+};
+
 class option {
 public:
 	option(string _msg) : msg(_msg) {};	
 	string msg;
 	virtual bool parse(string) = 0; 
-	virtual string val() = 0; 
+	virtual string val() = 0;
+	virtual OptionType type() = 0;
+	virtual string type_error(string val) = 0;
 };
 
 class intoption : public option {
@@ -18,6 +27,16 @@ public:	intoption(int* p, int _lb, int _ub, string _msg) : option(_msg),
 	  int ub; // upper-bound
 	  bool parse(string st); 
 	  string val() { return to_string(*p_to_var); }
+	  OptionType type() { return INT_OPTION; }
+	  string type_error(string val) { return "value " + val + " not numeric"; }
+};
+
+class booloption : public intoption {
+public:	booloption(int* p, string _msg) : intoption((int*)p, 0, 1, _msg) {};
+	  bool parse(string st) override;
+	  string val() override { return *(p_to_var) ? "true" : "false"; }
+	  OptionType type() override { return BOOL_OPTION; }
+	  string type_error(string val) override { return "value " + val + " not boolean"; }
 };
 
 class doubleoption : public option {
@@ -28,6 +47,17 @@ public:	doubleoption(double* p, double _lb, double _ub, string _msg) : option(_m
 	  double ub; // upper-bound
 	  bool parse(string st);
 	  string val() { return to_string(*p_to_var); }
+	  OptionType type() { return DOUBLE_OPTION; }
+	  string type_error(string val) { return "value " + val + " not double"; }
+};
+
+class stringoption : public option {
+public:	stringoption(string* p, string _msg) : option(_msg), p_to_var(p) {}
+	  string* p_to_var; // pointer to the variable holding the option value. 
+	  bool parse(string st);
+	  string val() { return *p_to_var; }
+	  OptionType type() { return STRING_OPTION; }
+	  string type_error(string val) { return "value " + val + " not string"; }
 };
 void Abort(string s, int i);
-void parse_options(int argc, char** argv, bool &with_proof);
+void parse_options(int argc, char** argv);


### PR DESCRIPTION
- Introduced bool option (intended for the future preprocessing flag), if not value is given to a boolean flag, it will be set to true. If the flag is not specified, it's default is false.

- Introduced string option and added proof flag instead of infering the proof file exists. The default value is "", and a value must be provided after the flag.