### PR TITLE
Change cnf to unoredered_set of clauses

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -120,7 +120,7 @@ void Solver::read_cnf(ifstream &in)
 	cout << "Read " << cnf_size() << " clauses in " << read_cnf_time << " secs." << endl;
 }
 
-void Solver::read_cnf(const vector<BVA::Clause *> &cnf_, const int max_var)
+void Solver::read_cnf(const unordered_set<BVA::Clause *, BVA::ClauseHasher> &cnf_, const int max_var)
 {
 	set<Lit> s;
 	Clause c;

--- a/src/solver.h
+++ b/src/solver.h
@@ -96,7 +96,7 @@ public:
 		restart_upper(Restart_upper), restart_multiplier(Restart_multiplier) {};
 	~Solver() { delete proof_tracer; }
 	void read_cnf(ifstream& in);
-	void read_cnf(const vector<BVA::Clause *> &cnf, const int max_var);
+	void read_cnf(const unordered_set<BVA::Clause *, BVA::ClauseHasher> &cnf, const int max_var);
 	VarState get_lit_state(int l) { return state[l2v(l)]; }
 	SolverState _solve();
 	void solve();


### PR DESCRIPTION
- The unordered set stores pointers, therefore, had to pass a custom hash function which works on the contents of the pointer.

- When looking for a cnf, instead of using .find command, had to get all elements in a specific bucket and iterate over them and use the internal clausesAreIdentical function.