### PR TITLE
Add note regarding average calculations

### DIFF
--- a/performance/results.ipynb
+++ b/performance/results.ipynb
@@ -364,6 +364,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#! NOTE: In the excels, if EDUSAT-BVA timed out, preprocessing time and search time\n",
+    "# were not recorded. This means that the avg preprocessing time and avg search time for the\n",
+    "# EDUSAT-BVA tests are not accurate.\n",
     "def calculate_averages(results, title):\n",
     "    edusat_avg_solve_time = results['EDUSAT_solve_time'].mean()\n",
     "    edusat_bva_avg_search_time = results['EDUSAT-BVA_search_time'].mean()\n",


### PR DESCRIPTION
- In the cases when EDUSAT-BVA timed out, the preprocessing and search times weren't recorded
in the excels, thus, the averages in these areas weren't accurate.